### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,9 @@ class ItemsController < ApplicationController
 
  # 商品編集ページ
  def edit
+    unless current_user == @item.user
+      redirect_to root_path
+    end
  end
 
  private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_session, except: [:index, :show]
-  before_action :set_item, only: [:show]
+  before_action :set_item, only: [:show, :edit]
 
  # トップページ
  def index
@@ -26,6 +26,9 @@ class ItemsController < ApplicationController
  def show
  end
 
+ # 商品編集ページ
+ def edit
+ end
 
  private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,15 +28,13 @@ class ItemsController < ApplicationController
 
  # 商品編集ページ
  def edit
-    unless current_user == @item.user
-      redirect_to root_path
+      redirect_to root_path unless current_user  == @item.user
     end
  end
 
  # 商品情報の更新
  def update
-   if @item.update(item_params)
-       render action: :show
+       render action: :show if @item.update(item_params)
    end
  end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_session, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit]
+  before_action :set_item, only: [:show, :edit, :update]
 
  # トップページ
  def index
@@ -31,6 +31,13 @@ class ItemsController < ApplicationController
     unless current_user == @item.user
       redirect_to root_path
     end
+ end
+
+ # 商品情報の更新
+ def update
+   if @item.update(item_params)
+       render action: :show
+   end
  end
 
  private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,8 +33,12 @@ class ItemsController < ApplicationController
 
  # 商品情報の更新
  def update
-   render action: :show if @item.update(item_params)
- end
+  if @item.update(item_params)
+    redirect_to item_path(item_params)
+  else
+    render :edit
+  end
+end
  
 
  private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,15 +28,14 @@ class ItemsController < ApplicationController
 
  # 商品編集ページ
  def edit
-      redirect_to root_path unless current_user  == @item.user
-    end
+   redirect_to root_path unless current_user  == @item.user
  end
 
  # 商品情報の更新
  def update
-       render action: :show if @item.update(item_params)
-   end
+   render action: :show if @item.update(item_params)
  end
+ 
 
  private
 

--- a/app/javascript/calculation.js
+++ b/app/javascript/calculation.js
@@ -1,13 +1,32 @@
 function calculation() {
-  const price = document.getElementById('item-price');
-  const fee = document.getElementById('add-tax-price');
-  const profit = document.getElementById('profit');
+  const itemPrice = document.getElementById("item-price");
+  const addTax = document.getElementById("add-tax-price");
+  const profit = document.getElementById('profit') ;
 
-  price.addEventListener('input', function() {
-    const inputPrice = price.value;
-    fee.innerHTML = `${Math.floor(inputPrice * 0.1)}`;
-    profit.innerHTML = `${inputPrice - fee.innerHTML}`;
-  });
-};
+  const inputPrice = function() {
+    const priceContent = itemPrice.value;
 
-setInterval(calculation, 1000);
+    if(priceContent >= 300 && priceContent <= 9999999){
+      let tax = priceContent * 0.1
+      let taxContent = Math.round(tax);
+      let profitContent = priceContent - taxContent
+      let afterTaxContent = taxContent.toLocaleString();
+      let afterprofitContent = profitContent.toLocaleString();
+      addTax.textContent = afterTaxContent;
+      profit.textContent = afterprofitContent;
+
+    } else {
+      let taxContent = '0';
+      let profitContent = '0';
+      addTax.textContent = taxContent;
+      profit.textContent = profitContent;
+    } 
+  }
+
+  value =  inputPrice.innerHTML
+
+  itemPrice.addEventListener('click', inputPrice);
+}
+window.addEventListener('click', calculation);
+
+// innerHTMLどこに何を追加するか

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with local: model: @item, true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <% render 'shared/error_messages', model: @item %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:product_status_id, ProductStatus.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, {include_blank "---"}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_code_id, PrefectureCode.all, :id, :name, {include_blank "---"}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:handling_time_id, HandlingTime.all, :id, :name, {include_blank "---"}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: model: @item, true do |f| %>
+    <%= form_with  model: @item, local: true do |f| %>
 
     <% render 'shared/error_messages', model: @item %>
 
@@ -71,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, {include_blank "---"}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_code_id, PrefectureCode.all, :id, :name, {include_blank "---"}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_code_id, PrefectureCode.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:handling_time_id, HandlingTime.all, :id, :name, {include_blank "---"}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:handling_time_id, HandlingTime.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,7 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with  model: @item, local: true do |f| %>
 
-    <% render 'shared/error_messages', model: @item %>
+    <%= render 'shared/error_messages', model: @item %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -138,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%= f.submit "変更する", class:"sell-btn" %>
       <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -71,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_code_id, PrefectureCode.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_code_id, PrefectureCode.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:handling_time_id, HandlingTime.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:handling_time_id, HandlingTime.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
-       <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
+       <%= link_to '商品の編集', edit_item_path(item.id), method: :get, class: "item-red-btn" %>
        <p class='or-text'>or</p>
        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
-       <%= link_to '商品の編集', edit_item_path(item.id), method: :get, class: "item-red-btn" %>
+       <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
        <p class='or-text'>or</p>
        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
-       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+       <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
        <p class='or-text'>or</p>
        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
    devise_for :users
    root to: "items#index"
-   resources :items, only: [:new, :create, :show, :edit]
+   resources :items, only: [:new, :create, :show, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
    devise_for :users
    root to: "items#index"
-   resources :items, only: [:new, :create, :show]
+   resources :items, only: [:new, :create, :show, :edit]
 end


### PR DESCRIPTION
# What

* ルーディング及びedit、updateアクションの定義
* 商品情報編集ページ表示の実装

# Why

* 商品情報編集ページの実装のため

# Reference

* 【商品情報編集の変更】
https://gyazo.com/e14938e10ceafe949421eca7c4cf50e6
* 【他のユーザーでの商品情報編集へ遷移できない】
https://gyazo.com/2f9f39114d32732c32a49bd4ef288a3d
*【未ログイン時商品情報編集ページへは遷移せずログイン画面へ遷移する】
https://gyazo.com/5e93745db63b4c5df438e07aaff6c077
* 【未編集でも画像なしの商品にならない】
https://gyazo.com/52d3b31af166fd8d09635a9f4a09eaa0
* 【商品情報編集ページへの遷移】
https://gyazo.com/e78e006317e3c5daa8b91456690618bc
* 【エラーハンドリングができていること】
（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させる）
https://gyazo.com/e4720a8e884ad44aaaeab35c2d9a2e7c